### PR TITLE
chore: update golang-lint to version 1.55 for go1.21 compatibility.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Build
     env:
       GO_VERSION: 1.17
-      GOLANGCI_LINT_VERSION: v1.53
+      GOLANGCI_LINT_VERSION: v1.55
       YAEGI_VERSION: v0.10.0
       CGO_ENABLED: 0
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixed the errors that occurred during linting.

```
Error: ../../../../../opt/hostedtoolcache/go/1.21.5/x64/src/net/http/internal/chunked.go:79:14: undefined: max (typecheck)
	cr.excess = max(cr.excess, 0)
	            ^
```