### PR TITLE
feat: refresh keys when current jwt kid is not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ OpaDebugMode | Set the opa response in the http response body when the request i
 PayloadFields | The field-name in the JWT payload that are required (e.g. `exp`). Multiple field names may be specified (string array)
 Required | Is `Authorization` header with JWT token required for every request.
 Keys | Used to validate JWT signature. Multiple keys are supported. Allowed values include certificates, public keys, symmetric keys. In case the value is a valid URL, the plugin will fetch keys from the JWK endpoint.
+ForceRefreshKeys | Force fetching keys from JWKS service when the key of current JWT token is not found. If set false, keys will only be refreshed every 15 minutes by default.
 Alg | Used to verify which PKI algorithm is used in the JWT.
 JwksHeaders | Map used to add headers to a JWKS request (e.g. credentials for a 3rd party JWKS service).
 JwtHeaders | Map used to inject JWT payload fields as HTTP request headers.


### PR DESCRIPTION
I find that currently keys will only be fetched via JWKS endpoints every 15 minutes. Thus if a JWT token is created with a new key, it will be validated failed until the next background refresh.
So I have made the following changes:

1. If JWKS endpoint list is not empty, when a key ID is not found in the keys map, the background keys refresh will be forced to trigger before proceeding token verification.
2. A read-write lock is added to the `keys` map since it could be accessed by two goroutines.