### PR TITLE
Fixes #54

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -159,7 +159,7 @@ type PayloadInput struct {
 	Headers    map[string][]string    `json:"headers"`
 	JWTHeader  JwtHeader              `json:"tokenHeader"`
 	JWTPayload map[string]interface{} `json:"tokenPayload"`
-	Body       map[string]interface{} `json:"body,omitempty"`
+	Body       interface{}            `json:"body,omitempty"`
 	Form       url.Values             `json:"form,omitempty"`
 }
 

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -121,7 +121,7 @@ func TestServeOPAWithBody(t *testing.T) {
 		contentType    string
 		body           string
 		allowed        bool
-		expectedBody   map[string]interface{}
+		expectedBody   interface{}
 		expectedForm   url.Values
 		expectedStatus int
 		drainBody      bool
@@ -141,6 +141,28 @@ func TestServeOPAWithBody(t *testing.T) {
 			expectedBody: map[string]interface{}{
 				"killroy": "washere",
 			},
+			expectedStatus: http.StatusOK,
+			drainBody:      true,
+		},
+		{
+			name:        "jsonArray",
+			method:      "POST",
+			contentType: "application/json",
+			body:        `[ "killroy", "washere" ]`,
+			allowed:     true,
+			expectedBody: []interface{}{
+				"killroy", "washere",
+			},
+			expectedStatus: http.StatusOK,
+			drainBody:      true,
+		},
+		{
+			name:           "jsonLiteral",
+			method:         "POST",
+			contentType:    "application/json",
+			body:           `"killroy"`,
+			allowed:        true,
+			expectedBody:   "killroy",
 			expectedStatus: http.StatusOK,
 			drainBody:      true,
 		},


### PR DESCRIPTION
support for any type of JSON as request body to send to OPA (including arrays)

see also:
https://github.com/traefik-plugins/traefik-jwt-plugin/issues/54
